### PR TITLE
Fix doubled up toDegrees

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,12 +138,7 @@ export const useSensorFusion = () => useContext(SensorFusionContext);
 
 export const useCompass = () => {
   const { comp: [ x, y ] } = useSensorFusion();
-  return toDegrees(
-    Math.atan2(
-      y,
-      x,
-    ),
-  );
+  return Math.atan2(y, x);
 };
 
 export default SensorFusionProvider;


### PR DESCRIPTION
I think that this change had a bug e13585e37bf29e24e06e48379ce57f5e65ac8f08

Either that of the example is wrong because it effective calls ```toDegrees(toDegrees(Math.atan2(...))```

![image](https://user-images.githubusercontent.com/199471/74090121-00e7a980-4a76-11ea-9ada-56e2320f9855.png)
